### PR TITLE
Update to be canonical repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.16</version>
+  <version>1.17-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.16</tag>
+    <tag>HEAD</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   
   <scm>
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</developerConnection>
+    <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
     <tag>maven-license-plugin-1.14</tag>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>org.kohsuke</groupId>
+    <artifactId>pom</artifactId>
+    <version>21</version>
+    <relativePath />
   </parent>
 
   <groupId>com.cloudbees</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.12-SNAPSHOT</version>
+  <version>1.12</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>
@@ -24,7 +24,7 @@
     <connection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.12</tag>
   </scm>
     
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy</artifactId>
-      <version>1.6.5</version>
+      <artifactId>groovy-xml</artifactId>
+      <version>3.0.7</version>
     </dependency>
   </dependencies>
 
@@ -66,6 +66,14 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.8</version>
+  <version>1.9-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.16-SNAPSHOT</version>
+  <version>1.16</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.16</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.12</version>
+  <version>1.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>
@@ -24,7 +24,7 @@
     <connection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.12</tag>
+    <tag>HEAD</tag>
   </scm>
     
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>3.0.7</version>
+      <version>3.0.9</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.13</version>
+  <version>1.14-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>
@@ -22,7 +22,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.13</tag>
+    <tag>HEAD</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -79,5 +79,14 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version> <!-- TODO 2.10.3 in parent seems pretty broken -->
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>1.15</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.15</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
           <configuration>
             <skip>true</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>org.kohsuke</groupId>
-    <artifactId>pom</artifactId>
-    <version>21</version>
-    <relativePath />
-  </parent>
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
@@ -17,49 +11,100 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+    <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
+    <maven.version>3.8.6</maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   
   <scm>
-    <connection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</connection>
+    <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
     <tag>HEAD</tag>
   </scm>
     
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>2.0</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
       <version>4.0.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven-plugin-tools.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.5.1</version>
+        <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <goalPrefix>maven-license-plugin</goalPrefix>
+          <doclint>all,-missing</doclint>
+          <locale>en_US</locale>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>${maven-plugin-tools.version}</version>
+        <configuration>
+          <goalPrefix>license</goalPrefix>
         </configuration>
         <executions>
           <execution>
@@ -71,25 +116,121 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.0-M6</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>cloudbees-release</releaseProfiles>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>sonatype-nexus-staging</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jdk-8-and-below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <testSource>1.8</testSource>
+              <testTarget>1.8</testTarget>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>1.8</source>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+              <testRelease>8</testRelease>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>cloudbees-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,23 @@
   <version>1.14-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
-  <name>maven-license-plugin Maven Plugin</name>
-  <url>http://maven.apache.org</url>
+  <name>License Maven Plugin</name>
+  <url>https://github.com/cloudbees/maven-license-plugin</url>
+  <description>Maven plugin to process license information.</description>
+  <licenses>
+    <license>
+      <name>Apache 2.0 License</name>
+      <url>https://opensource.org/licenses/Apache-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>jglick</id>
+      <name>Jesse Glick</name>
+      <email>jglick@cloudbees.com</email>
+    </developer>
+  </developers>
 
   <properties>
     <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
@@ -20,8 +35,8 @@
   
   <scm>
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
-    <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
+    <developerConnection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</developerConnection>
+    <url>https://github.com/cloudbees/maven-license-plugin</url>
     <tag>HEAD</tag>
   </scm>
     

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.14-SNAPSHOT</version>
+  <version>1.14</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.14</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.14</version>
+  <version>1.15-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.14</tag>
+    <tag>HEAD</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
   </developers>
 
   <properties>
-    <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
-    <maven.version>3.8.6</maven.version>
+    <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
+    <maven.version>3.9.2</maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -77,12 +77,6 @@
       <version>${maven-plugin-tools.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -91,17 +85,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -133,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M6</version>
+        <version>3.0.1</version>
         <configuration>
           <useReleaseProfile>false</useReleaseProfile>
           <releaseProfiles>cloudbees-release</releaseProfiles>
@@ -209,7 +203,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.7-SNAPSHOT</version>
+  <version>1.7</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.9</version>
+  <version>1.10-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.10-SNAPSHOT</version>
+  <version>1.10</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.11-SNAPSHOT</version>
+  <version>1.12-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>
@@ -23,6 +23,8 @@
   <scm>
     <connection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
+    <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
+    <tag>HEAD</tag>
   </scm>
     
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.15</version>
+  <version>1.16-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.15</tag>
+    <tag>HEAD</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.17</version>
+  <version>1.18-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>maven-license-plugin-1.17</tag>
+    <tag>HEAD</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.8-SNAPSHOT</version>
+  <version>1.8</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
-    <maven.version>3.9.2</maven.version>
+    <maven.version>3.8.1</maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.7</version>
+  <version>1.8-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.10</version>
+  <version>1.11-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.9-SNAPSHOT</version>
+  <version>1.9</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version> <!-- TODO 2.10.3 in parent seems pretty broken -->
+          <configuration>
+            <skip>true</skip>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.17-SNAPSHOT</version>
+  <version>1.17</version>
   <packaging>maven-plugin</packaging>
 
   <name>License Maven Plugin</name>
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.17</tag>
   </scm>
     
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
       <version>2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>3.0.9</version>
+      <version>4.0.6</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
-  <version>1.13-SNAPSHOT</version>
+  <version>1.13</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-license-plugin Maven Plugin</name>
@@ -22,7 +22,7 @@
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-license-plugin-1.13</tag>
   </scm>
     
   <distributionManagement>

--- a/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
+++ b/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
@@ -10,8 +10,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static java.util.Collections.*;
-
 /**
  * Base class for completer scripts that define convenience methods.
  *
@@ -80,7 +78,7 @@ public class CompleterDelegate {
             throw error;
         }
 
-        dependency.setLicenses(singletonList(to));
+        dependency.setLicenses(Collections.singletonList(to));
     }
 
     /**
@@ -97,10 +95,10 @@ public class CompleterDelegate {
      * From the multi-licensed modules, accept one of them.
      */
     public void accept(String name) {
-        List<License> licenses = new ArrayList<License>(dependency.getLicenses());
+        List<License> licenses = new ArrayList<>(dependency.getLicenses());
         for (License lic : licenses) {
             if (lic.getName().equals(name)) {
-                dependency.setLicenses(new ArrayList<License>(Arrays.asList(lic)));
+                dependency.setLicenses(Collections.singletonList(lic));
                 return;
             }
         }

--- a/src/main/java/com/cloudbees/maven/license/ProcessMojo.java
+++ b/src/main/java/com/cloudbees/maven/license/ProcessMojo.java
@@ -32,6 +32,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -146,11 +147,21 @@ public class ProcessMojo extends AbstractMojo {
             }
         }
 
-        if (generateLicenseXml!=null)
-            comp.add((LicenseScript) shell.parse(getClass().getResourceAsStream("xmlgen.groovy"),"xmlgen.groovy"));
+        if (generateLicenseXml!=null) {
+            try {
+                comp.add((LicenseScript) shell.parse(getClass().getResource("xmlgen.groovy").toURI()));
+            } catch (URISyntaxException | IOException e) {
+                throw new MojoExecutionException("Failed to retrieve xmlgen.groovy", e);
+            }
+        }
 
-        if (generateLicenseHtml!=null)
-            comp.add((LicenseScript) shell.parse(getClass().getResourceAsStream("htmlgen.groovy"),"htmlgen.groovy"));
+        if (generateLicenseHtml!=null) {
+            try {
+                comp.add((LicenseScript) shell.parse(getClass().getResource("htmlgen.groovy").toURI()));
+            } catch (URISyntaxException | IOException e) {
+                throw new MojoExecutionException("Failed to retrieve htmlgen.groovy", e);
+            }
+        }
 
         if (inlineScript!=null)
             comp.add((LicenseScript)shell.parse(inlineScript,"inlineScript"));

--- a/src/main/java/com/cloudbees/maven/license/ProcessMojo.java
+++ b/src/main/java/com/cloudbees/maven/license/ProcessMojo.java
@@ -21,7 +21,6 @@ import groovy.lang.GroovyShell;
 import groovy.lang.Script;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -67,9 +66,6 @@ public class ProcessMojo extends AbstractMojo {
 
     @Component
     public ArtifactFactory artifactFactory;
-
-    @Parameter(defaultValue = "${localRepository}")
-    public ArtifactRepository localRepository;
 
     /**
      * Specifies completion/generation/filtering scripts.
@@ -176,7 +172,6 @@ public class ProcessMojo extends AbstractMojo {
                 ProjectBuildingRequest buildingRequest =
                         new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
                 buildingRequest.setRemoteRepositories(project.getRemoteArtifactRepositories());
-                buildingRequest.setLocalRepository(localRepository);
                 buildingRequest.setProcessPlugins(false); // improve performance
                 models.put(a, projectBuilder.build(pom, buildingRequest).getProject());
             } catch (ProjectBuildingException x) {

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,14 @@
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>process</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
https://github.com/cloudbees/maven-license-plugin/pull/15#issuecomment-1611911455 @NotMyFault I did not realize this repo already existed.

If merged, I may be able to manually push historical tags too. Then I would delete the @cloudbees repo (still need assistance with that from @tgill2 in our Ops), and work on sharing OSSRH permissions.

Would be cleaner to just transfer the repo (so we do not lose PR history) but that is blocked by the existence of this repo. The alternative is for @NotMyFault to _delete_ this repo and then I can ask for a transfer. WDYT?